### PR TITLE
Simplify InfoItemWidget

### DIFF
--- a/lib/widgets/modular_widgets/atomic_swap_widgets/active_swaps_list_item.dart
+++ b/lib/widgets/modular_widgets/atomic_swap_widgets/active_swaps_list_item.dart
@@ -42,7 +42,8 @@ class _ActiveSwapsListItemState extends State<ActiveSwapsListItem> {
   int _currentTime = ((DateTime.now().millisecondsSinceEpoch) / 1000).floor();
 
   final TextEditingController _secretController = TextEditingController();
-  final TextEditingController _depositAmountController = TextEditingController();
+  final TextEditingController _depositAmountController =
+      TextEditingController();
   final GlobalKey<FormState> _secretKey = GlobalKey();
   final GlobalKey<FormState> _depositAmountKey = GlobalKey();
 
@@ -168,39 +169,7 @@ class _ActiveSwapsListItemState extends State<ActiveSwapsListItem> {
           const SizedBox(
             height: 20.0,
           ),
-          Row(children: [
-            InfoItemWidget(
-              id: "Deposit ID",
-              value: (_htlc!.id.toString()),
-              preimageExists: preimage?.isNotEmpty,
-            ),
-            const SizedBox(
-              width: 10.0,
-            ),
-            InfoItemWidget(
-              id: "Hashlock",
-              value: FormatUtils.encodeHexString((_htlc!.hashLock)!).toString(),
-              preimageExists: preimage?.isNotEmpty,
-            ),
-            const SizedBox(
-              width: 10.0,
-            ),
-            (_recipientIsSelf == true)
-                ? InfoItemWidget(
-                    id: "Sender",
-                    value: _htlc!.timeLocked.toString(),
-              preimageExists: preimage?.isNotEmpty,
-                  )
-                : InfoItemWidget(
-                    id: "Recipient",
-                    value: _htlc!.hashLocked.toString(),
-              preimageExists: preimage?.isNotEmpty,
-                  ),
-            const SizedBox(
-              width: 10.0,
-            ),
-            _getKeyWidget(),
-          ]),
+          _getInfoItems(),
         ],
       ),
     );
@@ -351,7 +320,46 @@ class _ActiveSwapsListItemState extends State<ActiveSwapsListItem> {
     );
   }
 
-  Widget _getKeyWidget() {
+  Widget _getInfoItems() {
+    final multiplier = (preimage?.isEmpty ?? true) ? 0.18 : 0.139;
+    double itemWidth = MediaQuery.of(context).size.width * multiplier;
+    itemWidth = itemWidth > 240.0 ? 240.0 : itemWidth;
+    return Row(children: [
+      InfoItemWidget(
+        id: "Deposit ID",
+        value: (_htlc!.id.toString()),
+        width: itemWidth,
+      ),
+      const SizedBox(
+        width: 10.0,
+      ),
+      InfoItemWidget(
+        id: "Hashlock",
+        value: FormatUtils.encodeHexString((_htlc!.hashLock)!).toString(),
+        width: itemWidth,
+      ),
+      const SizedBox(
+        width: 10.0,
+      ),
+      (_recipientIsSelf == true)
+          ? InfoItemWidget(
+              id: "Sender",
+              value: _htlc!.timeLocked.toString(),
+              width: itemWidth,
+            )
+          : InfoItemWidget(
+              id: "Recipient",
+              value: _htlc!.hashLocked.toString(),
+              width: itemWidth,
+            ),
+      const SizedBox(
+        width: 10.0,
+      ),
+      _getKeyWidget(itemWidth),
+    ]);
+  }
+
+  Widget _getKeyWidget(double width) {
     if (preimage == null) {
       _getPreimage();
     }
@@ -360,7 +368,7 @@ class _ActiveSwapsListItemState extends State<ActiveSwapsListItem> {
       child: InfoItemWidget(
         id: "Secret",
         value: preimage!,
-        preimageExists: preimage?.isNotEmpty,
+        width: width,
       ),
     );
   }
@@ -570,9 +578,9 @@ class _ActiveSwapsListItemState extends State<ActiveSwapsListItem> {
             '"hashLock": "${base64.encode((_htlc?.hashLock)!)}"}';
 
         await sl.get<ActiveSwapsWorker>().addPendingSwap(
-          json: json,
-          //preimage: preimage,
-        );
+              json: json,
+              //preimage: preimage,
+            );
         setState(() {});
 
         //_sendUnlockHtlcBlock();

--- a/lib/widgets/reusable_widgets/dialogs/swap_dialogs/deposit_dialog.dart
+++ b/lib/widgets/reusable_widgets/dialogs/swap_dialogs/deposit_dialog.dart
@@ -101,7 +101,9 @@ showDepositDialog({
                   Row(
                     children: [
                       InfoItemWidget(
-                          id: "Deposit ID", value: htlc.id.toString(), shrinkable: false,),
+                        id: "Deposit ID",
+                        value: htlc.id.toString(),
+                      ),
                       const SizedBox(
                         width: 15.0,
                       ),
@@ -110,7 +112,6 @@ showDepositDialog({
                         value: (_creatingSwap)
                             ? htlc.hashLocked.toString()
                             : htlc.timeLocked.toString(),
-                        shrinkable: false,
                       )
                     ],
                   ),
@@ -314,8 +315,7 @@ showDepositDialog({
                           if (_creatingSwap) {
                             print("creating swap");
                             onCreateButtonPressed?.call();
-                          }
-                          else if (valid == true) {
+                          } else if (valid == true) {
                             print("valid");
                             onDepositButtonPressed!(_selectedToken);
                           } else {

--- a/lib/widgets/reusable_widgets/dialogs/swap_dialogs/unlock_dialog.dart
+++ b/lib/widgets/reusable_widgets/dialogs/swap_dialogs/unlock_dialog.dart
@@ -78,7 +78,6 @@ showUnlockDialog({
                   InfoItemWidget(
                     id: "Deposit ID",
                     value: htlc.id.toString(),
-                    shrinkable: false,
                   ),
                   const SizedBox(
                     width: 15.0,
@@ -86,7 +85,6 @@ showUnlockDialog({
                   InfoItemWidget(
                     id: "Sender",
                     value: htlc.timeLocked.toString(),
-                    shrinkable: false,
                   ),
                 ], // Deposit ID and Sender (info widgets)
               ),

--- a/lib/widgets/reusable_widgets/icons/copy_to_clipboard_icon.dart
+++ b/lib/widgets/reusable_widgets/icons/copy_to_clipboard_icon.dart
@@ -8,6 +8,7 @@ class CopyToClipboardIcon extends StatelessWidget {
   final Color? hoverColor;
   final MaterialTapTargetSize materialTapTargetSize;
   final IconData icon;
+  final EdgeInsets padding;
 
   const CopyToClipboardIcon(
     this.textToBeCopied, {
@@ -15,6 +16,7 @@ class CopyToClipboardIcon extends StatelessWidget {
     this.hoverColor,
     this.materialTapTargetSize = MaterialTapTargetSize.padded,
     this.icon = Icons.content_copy,
+    this.padding = const EdgeInsets.all(8.0),
     Key? key,
   }) : super(key: key);
 
@@ -24,7 +26,7 @@ class CopyToClipboardIcon extends StatelessWidget {
       materialTapTargetSize: materialTapTargetSize,
       hoverColor: hoverColor,
       constraints: const BoxConstraints.tightForFinite(),
-      padding: const EdgeInsets.all(8.0),
+      padding: padding,
       child: Icon(
         icon,
         color: iconColor,

--- a/lib/widgets/reusable_widgets/info_item_widget.dart
+++ b/lib/widgets/reusable_widgets/info_item_widget.dart
@@ -6,14 +6,12 @@ import 'package:zenon_syrius_wallet_flutter/widgets/reusable_widgets/icons/copy_
 class InfoItemWidget extends StatefulWidget {
   final String id;
   final String value;
-  final bool? shrinkable;
-  final bool? preimageExists;
+  final double width;
 
   const InfoItemWidget({
     required this.id,
     required this.value,
-    this.shrinkable,
-    this.preimageExists,
+    this.width = 240.0,
     Key? key,
   }) : super(key: key);
 
@@ -24,98 +22,65 @@ class InfoItemWidget extends StatefulWidget {
 class _InfoItemWidgetState extends State<InfoItemWidget> {
   @override
   Widget build(BuildContext context) {
-    double _width = 240;
-    bool _shrink = false;
-    if (widget.shrinkable != false) {
-      double _multiplier = (widget.preimageExists == true) ? 0.139 : 0.18;
-      _width = MediaQuery.of(context).size.width * _multiplier;
-      if (_width >= 240) {
-        _width = 240;
-      }
-      _shrink = (_width < 230) ? true : false;
-    }
+    final shouldShrink = widget.width < 230;
+    final hasValue = widget.value != "0" * 64;
     return Container(
-      padding: const EdgeInsets.symmetric(vertical: 5.0, horizontal: 10.0),
-      width: _width,
+      padding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 15.0),
+      width: widget.width,
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(
           8.0,
         ),
         color: Theme.of(context).dividerTheme.color,
       ),
-      child: Padding(
-        padding: const EdgeInsets.only(
-          left: 5.0,
-          top: 5.0,
-          bottom: 5.0,
-        ),
-        child: Column(
-          children: [
-            Visibility(
-              visible: _shrink,
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.start,
-                children: [
-                  Text(
-                    widget.id,
-                    style: Theme.of(context).textTheme.subtitle1,
-                    textAlign: TextAlign.center,
-                  ),
-                  const Spacer(),
-                ],
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Visibility(
+            visible: shouldShrink,
+            child: Text(
+              widget.id,
+              style: Theme.of(context).textTheme.subtitle1,
+            ),
+          ),
+          Row(
+            children: <Widget>[
+              Visibility(
+                visible: !shouldShrink,
+                child: Text(
+                  widget.id,
+                  style: Theme.of(context).textTheme.subtitle1,
+                ),
               ),
-            ),
-            Row(
-              children: <Widget>[
-                Visibility(
-                  visible: !_shrink,
-                  child: Text(
-                    widget.id,
-                    style: Theme.of(context).textTheme.subtitle1,
-                    textAlign: TextAlign.left,
-                  ),
+              Visibility(
+                visible: !shouldShrink,
+                child: const Spacer(),
+              ),
+              hasValue
+                  ? Text(
+                      FormatUtils.formatLongString(widget.value),
+                      style: Theme.of(context).textTheme.bodyText2,
+                      textAlign: TextAlign.center,
+                    )
+                  : Text(
+                      "Pending...",
+                      style: Theme.of(context).textTheme.bodyText2,
+                      textAlign: TextAlign.center,
+                    ),
+              Visibility(
+                  visible: hasValue && shouldShrink, child: const Spacer()),
+              Visibility(
+                visible: hasValue,
+                child: CopyToClipboardIcon(
+                  widget.value,
+                  iconColor: AppColors.lightPrimaryContainer,
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  padding: const EdgeInsets.only(left: 8.0),
                 ),
-                Visibility(
-                  visible: !_shrink,
-                  child: const Spacer(),
-                ),
-                Row(
-                  children: (widget.value == "0" * 64)
-                      ? [
-                          Text(
-                            "Pending...",
-                            style: Theme.of(context).textTheme.bodyText2,
-                            textAlign: TextAlign.center,
-                          ),
-                          const SizedBox(
-                            width: 15.0,
-                            height: 30.0,
-                          ),
-                        ]
-                      : [
-                          Text(
-                            FormatUtils.formatLongString(widget.value),
-                            style: Theme.of(context).textTheme.bodyText2,
-                            textAlign: TextAlign.center,
-                          ),
-                          //const Spacer(),
-                        ],
-                ),
-                Visibility(
-                    visible: (widget.value != "0" * 64 && _shrink),
-                    child: const Spacer()),
-                Visibility(
-                  visible: (widget.value != "0" * 64),
-                  child: CopyToClipboardIcon(
-                    widget.value,
-                    iconColor: AppColors.lightPrimaryContainer,
-                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                  ),
-                ),
-              ],
-            ),
-          ],
-        ),
+              ),
+            ],
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
The goal of this PR is to simplify the InfoItemWidget and to better match the [intended design](https://www.figma.com/file/oUEsSuMCyAdVCeBFwx5UPc/syrius_atomic_swaps) by decreasing vertical padding.

The `shrinkable` and `preimageExists` properties have been removed from the `InfoItemWidget`. This widget could be reused in other places so it shouldn't have to know about the preimage.

To simplify the "shrink" logic for the widget I moved the responsibility of changing the widget's width to the parent widget.

I also used some different coding conventions in some areas:

Boolean evaluations:
https://dart.dev/guides/language/effective-dart/usage#prefer-using--to-convert-null-to-a-boolean-value

Boolean naming:
https://dart.dev/guides/language/effective-dart/design#prefer-a-non-imperative-verb-phrase-for-a-boolean-property-or-variable

Using final:
https://dart.dev/guides/language/language-tour#final-and-const

Avoiding underscores in local variables:
https://dart.dev/guides/language/effective-dart/style#dont-use-a-leading-underscore-for-identifiers-that-arent-private

I think going forward we could try and follow some guidelines like [this ](https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo) and [this](https://dart.dev/guides/language/effective-dart/style) so that we're all on the same page.

