### PR TITLE
Refactor ActiveSwapsListItem

### DIFF
--- a/lib/utils/format_utils.dart
+++ b/lib/utils/format_utils.dart
@@ -38,35 +38,6 @@ class FormatUtils {
     return DateFormat(dateFormat).format(date);
   }
 
-  static String formatExpirationTime(int expirationTime) {
-    const int minute = 60;
-    const int hour = 60 * minute;
-    const int day = 24 * hour;
-
-    int s, m, h, d = 0;
-    String formattedTime = "";
-
-    if (expirationTime > day) {
-      d = expirationTime ~/ day;
-      expirationTime %= day;
-      formattedTime += "$d d ";
-    }
-    if (expirationTime > hour) {
-      h = expirationTime ~/ hour;
-      expirationTime %= hour;
-      formattedTime += "$h h ";
-    }
-    if (expirationTime > minute) {
-      m = expirationTime ~/ minute;
-      expirationTime %= minute;
-      formattedTime += "$m min ";
-    }
-    s = expirationTime.remainder(minute);
-    formattedTime += "$s s";
-
-    return (formattedTime);
-  }
-
   static String extractNameFromEnum<T>(T enumValue) {
     String valueName = enumValue.toString().split('.')[1];
     if (RegExp(r'^[a-z]+[A-Z]+').hasMatch(valueName)) {

--- a/lib/widgets/modular_widgets/atomic_swap_widgets/active_swaps_card.dart
+++ b/lib/widgets/modular_widgets/atomic_swap_widgets/active_swaps_card.dart
@@ -251,18 +251,17 @@ class _ActiveSwapsCardState extends State<ActiveSwapsCard> {
                                 return ActiveSwapsListItem(
                                   key: ValueKey(htlc.id.toString()),
                                   htlcInfo: htlc,
-                                  getCurrentStatus: _inspectHtlc,
                                   onStepperNotificationSeeMorePressed: widget
                                       .onStepperNotificationSeeMorePressed,
                                 );
                               });
                         } else {
                           if (!sl.get<ActiveSwapsWorker>().synced) {
-                            return Column (
-                                children: [
-                                  const SyriusLoadingWidget(),
-                                  Text("Syncing swap history. Please wait..."),
-                                  ],
+                            return Column(
+                              children: [
+                                const SyriusLoadingWidget(),
+                                Text("Syncing swap history. Please wait..."),
+                              ],
                             );
                           }
                           if (_searchKeyWordController.text.isNotEmpty) {

--- a/lib/widgets/reusable_widgets/htlc_status_details.dart
+++ b/lib/widgets/reusable_widgets/htlc_status_details.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:zenon_syrius_wallet_flutter/utils/extensions.dart';
+import 'package:zenon_syrius_wallet_flutter/widgets/reusable_widgets/loading_widget.dart';
+
+enum HtlcDetailsStatus {
+  locking,
+  unlocking,
+  reclaiming,
+  inProgress,
+  expired,
+}
+
+class HtlcStatusDetails extends StatelessWidget {
+  final int hashType;
+  final int expirationTime;
+  final HtlcDetailsStatus status;
+
+  const HtlcStatusDetails({
+    Key? key,
+    required this.hashType,
+    required this.expirationTime,
+    required this.status,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final List<Widget> children = [];
+
+    if ([
+      HtlcDetailsStatus.locking,
+      HtlcDetailsStatus.unlocking,
+      HtlcDetailsStatus.reclaiming
+    ].contains(status)) {
+      String statusText = 'Locking deposit';
+      if (status == HtlcDetailsStatus.unlocking) {
+        statusText = 'Unlocking deposit';
+      } else if (status == HtlcDetailsStatus.reclaiming) {
+        statusText = 'Reclaiming deposit';
+      }
+      children.add(
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const SyriusLoadingWidget(
+              size: 12.0,
+              strokeWidth: 1.0,
+            ),
+            const SizedBox(
+              width: 8.0,
+            ),
+            Text(
+              statusText,
+              style: Theme.of(context).textTheme.subtitle1,
+            ),
+          ],
+        ),
+      );
+    }
+
+    if (status == HtlcDetailsStatus.inProgress) {
+      children.add(
+        StreamBuilder(
+          stream: Stream.periodic(const Duration(seconds: 1)),
+          builder: (context, snapshot) {
+            final remaining = _computeSecondsRemaining(expirationTime);
+            return Text(
+              'Expires in ${_formatTime(remaining)}',
+              style: Theme.of(context).textTheme.subtitle1,
+            );
+          },
+        ),
+      );
+    }
+
+    if (status == HtlcDetailsStatus.expired) {
+      children.add(
+        Text(
+          'Swap has expired',
+          style: Theme.of(context).textTheme.subtitle1,
+        ),
+      );
+    }
+
+    if (hashType == 1) {
+      children.add(
+        Text(
+          'SHA-256',
+          style: Theme.of(context).textTheme.subtitle1,
+        ),
+      );
+    }
+
+    return SizedBox(
+      height: 20.0,
+      child: Row(
+        children: children.zip(
+          List.generate(
+            children.length - 1,
+            (index) => Text(
+              '   ●   ',
+              style: Theme.of(context).textTheme.subtitle1,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  int _computeSecondsRemaining(int expirationTime) {
+    final remaining = expirationTime -
+        ((DateTime.now().millisecondsSinceEpoch) / 1000).floor();
+    return remaining > 0 ? remaining : 0;
+  }
+
+  String _formatTime(int seconds) {
+    return Duration(seconds: seconds).toString().split('.').first;
+  }
+}


### PR DESCRIPTION
Below is an overview of the refactoring done in this PR to the ActiveSwapsListItem widget. The goal was to better adhere to the coding style used throughout the codebase. The buttons' logic was left untouched for now, but they probably need some refactoring as well.

- Instead of using booleans to manage the state of the widget, the widget tree itself re-evaluates the state of the widgets when rebuilt.

 - FutureBuilder doesn't have to be removed from the widget tree because it remembers the last result of the future and won't call the async operation again on every rebuild.

 - The `_getCurrentStatus()` function was removed for now because I think it should be considered if showing incoming deposits that have expired is desirable.

 - Opted to use the already existing [extractDecimals](https://github.com/Sol-Sanctum/znn_sdk_dart/blob/spork_htlc/lib/src/utils/amount.dart#L4) function in the SDK's `AmountUtils` class.

 - The `getCurrentStatus` parameter was removed from the widget.

 - Moved the swap's status details into the new `HtlcStatusDetails` widget.

 - Removed `formatExpirationTime` from `FormatUtils` and added a simplified version to the `HtlcStatusDetails` widget.

**Note: these changes could break some existing functionality that I didn't realize.**