### PR TITLE
Generalize InfoItemWidget

### DIFF
--- a/lib/widgets/modular_widgets/atomic_swap_widgets/active_swaps_list_item.dart
+++ b/lib/widgets/modular_widgets/atomic_swap_widgets/active_swaps_list_item.dart
@@ -212,6 +212,7 @@ class _ActiveSwapsListItemState extends State<ActiveSwapsListItem> {
   }
 
   Widget _getInfoItems() {
+    final hasId = widget.htlcInfo!.id.toString() != "0" * 64;
     final preimage = _getPreimage();
     final multiplier = preimage.isEmpty ? 0.18 : 0.139;
     double itemWidth = MediaQuery.of(context).size.width * multiplier;
@@ -219,24 +220,26 @@ class _ActiveSwapsListItemState extends State<ActiveSwapsListItem> {
     final List<Widget> children = [];
     children.addAll([
       InfoItemWidget(
-        id: 'Deposit ID',
-        value: (widget.htlcInfo!.id.toString()),
+        label: 'Deposit ID',
+        value: hasId ? widget.htlcInfo!.id.toString() : 'Pending...',
         width: itemWidth,
+        canBeCopied: hasId,
+        truncateValue: hasId,
       ),
       InfoItemWidget(
-        id: 'Hashlock',
+        label: 'Hashlock',
         value: FormatUtils.encodeHexString((widget.htlcInfo!.hashLock)!)
             .toString(),
         width: itemWidth,
       ),
       _isIncomingDeposit()
           ? InfoItemWidget(
-              id: 'Sender',
+              label: 'Sender',
               value: widget.htlcInfo!.timeLocked.toString(),
               width: itemWidth,
             )
           : InfoItemWidget(
-              id: 'Recipient',
+              label: 'Recipient',
               value: widget.htlcInfo!.hashLocked.toString(),
               width: itemWidth,
             ),
@@ -244,7 +247,7 @@ class _ActiveSwapsListItemState extends State<ActiveSwapsListItem> {
     if (preimage.isNotEmpty) {
       children.add(
         InfoItemWidget(
-          id: 'Secret',
+          label: 'Secret',
           value: preimage,
           width: itemWidth,
         ),

--- a/lib/widgets/reusable_widgets/dialogs/swap_dialogs/deposit_dialog.dart
+++ b/lib/widgets/reusable_widgets/dialogs/swap_dialogs/deposit_dialog.dart
@@ -101,14 +101,14 @@ showDepositDialog({
                   Row(
                     children: [
                       InfoItemWidget(
-                        id: "Deposit ID",
+                        label: "Deposit ID",
                         value: htlc.id.toString(),
                       ),
                       const SizedBox(
                         width: 15.0,
                       ),
                       InfoItemWidget(
-                        id: "Recipient",
+                        label: "Recipient",
                         value: (_creatingSwap)
                             ? htlc.hashLocked.toString()
                             : htlc.timeLocked.toString(),

--- a/lib/widgets/reusable_widgets/dialogs/swap_dialogs/unlock_dialog.dart
+++ b/lib/widgets/reusable_widgets/dialogs/swap_dialogs/unlock_dialog.dart
@@ -76,14 +76,14 @@ showUnlockDialog({
               Row(
                 children: [
                   InfoItemWidget(
-                    id: "Deposit ID",
+                    label: "Deposit ID",
                     value: htlc.id.toString(),
                   ),
                   const SizedBox(
                     width: 15.0,
                   ),
                   InfoItemWidget(
-                    id: "Sender",
+                    label: "Sender",
                     value: htlc.timeLocked.toString(),
                   ),
                 ], // Deposit ID and Sender (info widgets)

--- a/lib/widgets/reusable_widgets/info_item_widget.dart
+++ b/lib/widgets/reusable_widgets/info_item_widget.dart
@@ -3,30 +3,28 @@ import 'package:zenon_syrius_wallet_flutter/utils/app_colors.dart';
 import 'package:zenon_syrius_wallet_flutter/utils/format_utils.dart';
 import 'package:zenon_syrius_wallet_flutter/widgets/reusable_widgets/icons/copy_to_clipboard_icon.dart';
 
-class InfoItemWidget extends StatefulWidget {
-  final String id;
+class InfoItemWidget extends StatelessWidget {
+  final String label;
   final String value;
   final double width;
+  final bool canBeCopied;
+  final bool truncateValue;
 
   const InfoItemWidget({
-    required this.id,
+    required this.label,
     required this.value,
     this.width = 240.0,
+    this.canBeCopied = true,
+    this.truncateValue = true,
     Key? key,
   }) : super(key: key);
 
   @override
-  State<InfoItemWidget> createState() => _InfoItemWidgetState();
-}
-
-class _InfoItemWidgetState extends State<InfoItemWidget> {
-  @override
   Widget build(BuildContext context) {
-    final shouldShrink = widget.width < 230;
-    final hasValue = widget.value != "0" * 64;
+    final shouldShrink = width < 230;
     return Container(
       padding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 15.0),
-      width: widget.width,
+      width: width,
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(
           8.0,
@@ -39,7 +37,7 @@ class _InfoItemWidgetState extends State<InfoItemWidget> {
           Visibility(
             visible: shouldShrink,
             child: Text(
-              widget.id,
+              label,
               style: Theme.of(context).textTheme.subtitle1,
             ),
           ),
@@ -48,7 +46,7 @@ class _InfoItemWidgetState extends State<InfoItemWidget> {
               Visibility(
                 visible: !shouldShrink,
                 child: Text(
-                  widget.id,
+                  label,
                   style: Theme.of(context).textTheme.subtitle1,
                 ),
               ),
@@ -56,23 +54,17 @@ class _InfoItemWidgetState extends State<InfoItemWidget> {
                 visible: !shouldShrink,
                 child: const Spacer(),
               ),
-              hasValue
-                  ? Text(
-                      FormatUtils.formatLongString(widget.value),
-                      style: Theme.of(context).textTheme.bodyText2,
-                      textAlign: TextAlign.center,
-                    )
-                  : Text(
-                      "Pending...",
-                      style: Theme.of(context).textTheme.bodyText2,
-                      textAlign: TextAlign.center,
-                    ),
+              Text(
+                truncateValue ? FormatUtils.formatLongString(value) : value,
+                style: Theme.of(context).textTheme.bodyText2,
+                textAlign: TextAlign.center,
+              ),
               Visibility(
-                  visible: hasValue && shouldShrink, child: const Spacer()),
+                  visible: canBeCopied && shouldShrink, child: const Spacer()),
               Visibility(
-                visible: hasValue,
+                visible: canBeCopied,
                 child: CopyToClipboardIcon(
-                  widget.value,
+                  value,
                   iconColor: AppColors.lightPrimaryContainer,
                   materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
                   padding: const EdgeInsets.only(left: 8.0),


### PR DESCRIPTION
The purpose of this PR is to generalize the InfoItemWidget so that it can be used in other places not related to atomic swaps. The widget now has two new boolean properties: `canBeCopied` and `truncateValue`.

Note: This brakes the "Pending..." info item in the Create Swap confirmation dialog but I think showing the sender in it's place would be a better idea.